### PR TITLE
SSD-607 Downgrade Python Version Requirement in DaailyAPIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ cp .env.example .env
 pip install -r tests/requirements.txt
 ```
 
+NOTE: Before publishing an new version, make sure that the development changes are merged into the main (production) branch.
+
 ## Push New Version
 
 Increment version by doing the following steps (ensure you have gcloud installed and authenticated):

--- a/cloudbuild-test-suite.yaml
+++ b/cloudbuild-test-suite.yaml
@@ -1,10 +1,10 @@
 steps:
 
-  - name: python:3.11
+  - name: python:3.10
     entrypoint: python
     args: ['-m', 'pip', 'install', '-r', 'tests/requirements.txt', '--user']
 
-  - name: python:3.11
+  - name: python:3.10
     entrypoint: 'python'
     args: ['-m', 'pytest', '-v']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ authors = [
 ]
 description = "Daaily API Library"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 dependencies = ["urllib3>=2.1.0,<3.0"]
 
 dynamic = ["version"]


### PR DESCRIPTION
Currently, daailyapis python requirement is equal to or bigger than 3.12, we need to change it to 3.10 at least