### PR TITLE
SSD-830 Sparky: Add Signed Urls Support for Manufacturer PDFs

### DIFF
--- a/daaily/lucy/resources/manufacturer.py
+++ b/daaily/lucy/resources/manufacturer.py
@@ -660,7 +660,7 @@ class ManufacturersResource(BaseResource):
         m = add_about_to_manufacturer(m, about)
         return self._client.update_entity(EntityType.MANUFACTURER, m)
 
-    def upload_pdf(
+    def upload_pdf(  # noqa: C901
         self,
         manufacturer_id: int,
         pdf_path: str | None = None,
@@ -744,11 +744,14 @@ class ManufacturersResource(BaseResource):
             manufacturer_id=manufacturer_id
         )
         url = f"{self._client._base_url}{man_pdf_upload_url}"
+        params = {}
         if old_blob_id:
             old_extension = extract_extension_from_blob_id(old_blob_id)
             old_mime_type = extract_mime_type_from_extension(old_extension)
             if old_mime_type == content_type:
-                url += f"&old_blob_id={old_blob_id}"
+                params["old_blob_id"] = old_blob_id
+        if params:
+            url += "?" + urlencode(params)
         resp = self._client._do_request(
             "POST",
             url,

--- a/daaily/lucy/resources/manufacturer.py
+++ b/daaily/lucy/resources/manufacturer.py
@@ -3,7 +3,7 @@ import mimetypes
 import os
 import re
 from typing import Any, Dict, Generator, Literal
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import urllib3
 
@@ -800,15 +800,18 @@ class ManufacturersResource(BaseResource):
             )
             ```
         """
-        url = MANUFACTURER_PDF_SIGNED_URL_ENDPOINT.format(
+        man_pdf_signed_url_pathname = MANUFACTURER_PDF_SIGNED_URL_ENDPOINT.format(
             manufacturer_id=manufacturer_id
         )
+        url = f"{self._client._base_url}{man_pdf_signed_url_pathname}"
         params = {}
         if pdf_title:
             params["pdf_title"] = pdf_title
         if old_blob_id:
             params["old_blob_id"] = old_blob_id
-        resp = self._client._do_request("POST", url, query_string=params)
+        if params:
+            url += "?" + urlencode(params)
+        resp = self._client._do_request("POST", url)
         if resp.status != 200:
             raise Exception(
                 f"Failed to get signed URL. Status code: {resp.status}. {resp.data}"

--- a/daaily/lucy/resources/manufacturer.py
+++ b/daaily/lucy/resources/manufacturer.py
@@ -766,7 +766,7 @@ class ManufacturersResource(BaseResource):
         manufacturer_id: int,
         pdf_title: str | None = None,
         old_blob_id: str | None = None,
-    ) -> Response:
+    ) -> Any:
         """
         Requests a signed URL for uploading a PDF file to GCS.
         This method sends a request to Lydia for a signed URL that can be used to
@@ -780,7 +780,7 @@ class ManufacturersResource(BaseResource):
                 If provided, it will be used to check if the existing PDF can be
                 replaced.
         Returns:
-            Response: The response from the server containing the signed URL and other
+            Any: The response from the server containing the signed URL and other
                 details.
                 For example:
                     {

--- a/samples/lucy/get_manufacturer_pdf_signed_url.py
+++ b/samples/lucy/get_manufacturer_pdf_signed_url.py
@@ -1,0 +1,21 @@
+import os
+
+from daaily.lucy import Client
+from daaily.lucy.constants import LUCY_V2_BASE_URL_STAGING
+
+# Get the directory of the current file
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Instantiate the client and overwrite the base URL with staging environment
+client = Client(base_url=LUCY_V2_BASE_URL_STAGING)
+
+manufacturer_id = 3100777
+
+try:
+    signed_url = client.manufacturers.get_pdf_signed_url(
+        manufacturer_id=manufacturer_id,
+        pdf_title="vitra product catalogue",
+    )
+    print("Pdf Signed Url:", signed_url)
+except Exception as e:
+    print(f"An error occurred while getting pdf signed url: {e}")

--- a/samples/lucy/get_manufacturer_pdf_signed_url.py
+++ b/samples/lucy/get_manufacturer_pdf_signed_url.py
@@ -19,3 +19,13 @@ try:
     print("Pdf Signed Url:", signed_url)
 except Exception as e:
     print(f"An error occurred while getting pdf signed url: {e}")
+
+
+try:
+    signed_url = client.manufacturers.get_pdf_preview_signed_url(
+        manufacturer_id=manufacturer_id,
+        mime_type="image/png",
+    )
+    print("Pdf Preview Signed Url:", signed_url)
+except Exception as e:
+    print(f"An error occurred while getting pdf preview signed url: {e}")

--- a/samples/lucy/upload_manufacturer_pdf_to_gcs.py
+++ b/samples/lucy/upload_manufacturer_pdf_to_gcs.py
@@ -1,0 +1,39 @@
+import os
+
+from daaily.lucy import Client
+from daaily.lucy.constants import LUCY_V2_BASE_URL_STAGING
+
+# Get the directory of the current file
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Instantiate the client and overwrite the base URL with staging environment
+client = Client(base_url=LUCY_V2_BASE_URL_STAGING)
+
+manufacturer_id = 3100777
+
+# Construct the path to the file in the neighboring directory
+pdf_path = os.path.join(script_dir, "..", "assets", "vitra.pdf")
+
+try:
+    uploaded_pdf = client.manufacturers.upload_pdf(
+        manufacturer_id=manufacturer_id,
+        pdf_path=pdf_path,
+        filename="vitra.pdf",
+    )
+    print("Uploaded pdf to gcs with file path:", uploaded_pdf)
+except Exception as e:
+    print(f"An error occurred while uploading pdf to gcs: {e}")
+
+
+try:
+    with open(pdf_path, "rb") as pdf_file:
+        pdf_bytes = pdf_file.read()
+    uploaded_pdf = client.manufacturers.upload_pdf(
+        manufacturer_id=manufacturer_id,
+        pdf_bytes=pdf_bytes,
+        filename="vitra.pdf",
+        mime_type="application/pdf",
+    )
+    print("Uploaded pdf to gcs with bytes:", uploaded_pdf)
+except Exception as e:
+    print(f"An error occurred while uploading pdf to gcs: {e}")


### PR DESCRIPTION
This PR adds support for signed URLs for manufacturer PDFs by extending the manufacturer resource and includes sample scripts demonstrating PDF uploads (by file path and binary data) and retrieval of signed URLs, including preview signed URLs for PDF preview images.

- Introduces new endpoints and methods for PDF upload and signed URL retrieval.
- Provides two sample scripts to demonstrate PDF upload and signed URL retrieval.
- Updates the manufacturer resource with methods for PDF uploads, signed URLs, and preview signed URLs.