### PR TITLE
SSD-832 Sparky: Add Signed Urls Support for Product PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ pip install git+ssh://git@github.com/DAAily/daailyapis-python-client.git
 
 Latest stable release:
 ```bash
-pip install git+ssh://github.com/DAAily/daailyapis-python-client.git@v1.12.37#egg=daaily
+pip install git+ssh://github.com/DAAily/daailyapis-python-client.git@v1.13.6#egg=daaily
 ```
   
 In case you want to work with the score client you need to install additional dependencies:
 ```bash
-pip install git+ssh://github.com/DAAily/daailyapis-python-client.git@v1.12.37#egg=daaily[score]
+pip install git+ssh://github.com/DAAily/daailyapis-python-client.git@v1.13.6#egg=daaily[score]
 ```
 
 

--- a/daaily/lucy/resources/product/resource.py
+++ b/daaily/lucy/resources/product/resource.py
@@ -389,6 +389,7 @@ class ProductsResource(BaseResource):
         self,
         product_id: int,
         mime_type: str,
+        pdf_type: str | None = None,
         old_blob_id: str | None = None,
     ) -> Any:
         """
@@ -399,6 +400,7 @@ class ProductsResource(BaseResource):
         Args:
             product_id (int): The unique identifier of the product.
             mime_type (str): The MIME type of the preview image.
+            pdf_type (str | None): The type of the PDF file.
             old_blob_id (str | None): The blob ID of the existing preview image.
                 If provided, it will be used to check if the existing image can be
                 replaced.
@@ -432,6 +434,8 @@ class ProductsResource(BaseResource):
             params["old_blob_id"] = old_blob_id
         if mime_type:
             params["mime_type"] = mime_type
+        if pdf_type:
+            params["pdf_type"] = pdf_type
         if params:
             url += "?" + urlencode(params)
         resp = self._client._do_request("POST", url)

--- a/daaily/version.py
+++ b/daaily/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.37"
+__version__ = "1.13.6"

--- a/samples/lucy/get_product_pdf_signed_url.py
+++ b/samples/lucy/get_product_pdf_signed_url.py
@@ -26,6 +26,7 @@ try:
     signed_url = client.products.get_pdf_preview_signed_url(
         product_id=product_id,
         mime_type="image/png",
+        pdf_type="booklet",
     )
     print("Pdf Preview Signed Url:", signed_url)
 except Exception as e:


### PR DESCRIPTION

This PR adds support for signed URLs for product PDFs by introducing a new parameter, pdf_type, across multiple components. The key changes include:
- Adding the pdf_type parameter in the signed URL generation endpoint.
- Updating the client call and its documentation to support the new pdf_type.
- Bumping the package version and updating the README accordingly.